### PR TITLE
:lock:validation: seguridad para password del registro

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,24 @@ Archivo `routes/web.php` expone metadata y enlaces útiles:
 1. **Registro público**: Campo `role` obligatorio ("patient" o "doctor")
 2. **Gestión admin**: Endpoint `PUT /api/admin/users/{user}/role`
 
+## ✅ Validaciones de Seguridad
+
+### **Registro de Usuario**
+- **Email**: Obligatorio, formato válido, único en la base de datos
+- **Password**:
+    - Mínimo 8 caracteres, máximo 64 caracteres
+    - Al menos una letra minúscula
+    - Al menos una letra mayúscula
+    - Al menos un número
+    - Confirmación requerida (`password_confirmation`)
+- **Name**: Obligatorio, máximo 255 caracteres
+
+### **Login**
+- **Email**: Obligatorio, formato válido
+- **Password**: Obligatorio
+
+> **Nota:** Las reglas de complejidad de contraseña solo aplican durante el registro. En el login se validan las credenciales contra la base de datos.
+
 ## 🗑️ Soft Deletes
 
 El sistema implementa soft deletes para mantener la integridad de datos:

--- a/app/Http/Requests/Auth/RegisterRequest.php
+++ b/app/Http/Requests/Auth/RegisterRequest.php
@@ -3,7 +3,7 @@
 namespace App\Http\Requests\Auth;
 
 use App\Http\Requests\BaseRequest;
-use Illuminate\Validation\Rule;
+use Illuminate\Validation\Rules\Password;
 
 class RegisterRequest extends BaseRequest
 {
@@ -17,18 +17,14 @@ class RegisterRequest extends BaseRequest
         return [
             'name' => 'required|string|max:255',
             'email' => 'required|email|unique:users',
-            'password' => 'required|string|min:8|confirmed',
-        ];
-    }
-
-    /**
-     * Custom messages for validation errors
-     */
-    public function messages(): array
-    {
-        return [
-            'role.required' => 'Debe especificar el tipo de usuario (paciente o doctor)',
-            'role.in' => 'El rol debe ser paciente o doctor',
+            'password' => [
+                'required',
+                'confirmed',
+                Password::min(8)
+                    ->max(64)
+                    ->mixedCase()
+                    ->numbers()
+            ]
         ];
     }
 }


### PR DESCRIPTION
#26 

Implementa validaciones para endpoints de registro y documenta en README.

## ✨ Cambios
- Validaciones en `RegisterRequest`: email único, password con requisitos de complejidad
- Documentación en README

## 🔒 Validaciones implementadas
**Registro:** Email único, password (8-64 chars, mayúsculas, minúsculas, números), name(max-255)  

## 📝 Archivos modificados
- `app/Http/Requests/Auth/RegisterRequest.php`
- `README.md`

Closes #26 